### PR TITLE
Bumped to 1.0.17 of xrstf/composer-php52

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1b35674f6114ac510575d1de6e38a141",
+    "hash": "22ea37ec3ca2858abdb3ffa6c572f10e",
     "packages": [
         {
             "name": "xrstf/composer-php52",
-            "version": "v1.0.16",
+            "version": "v1.0.17",
             "source": {
                 "type": "hg",
                 "url": "https://bitbucket.org/xrstf/composer-php52",
-                "reference": "b80de08b940ea59789646fa20d841fbdd72d72f0"
+                "reference": "70b853668d6c3f97b63dafcfaeebb622bf08fd30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://bitbucket.org/xrstf/composer-php52/get/b80de08b940ea59789646fa20d841fbdd72d72f0.zip",
-                "reference": "b80de08b940ea59789646fa20d841fbdd72d72f0",
+                "url": "https://bitbucket.org/xrstf/composer-php52/get/70b853668d6c3f97b63dafcfaeebb622bf08fd30.zip",
+                "reference": "70b853668d6c3f97b63dafcfaeebb622bf08fd30",
                 "shasum": ""
             },
             "type": "library",
@@ -36,7 +36,7 @@
                 "MIT"
             ],
             "homepage": "http://www.xrstf.de/",
-            "time": "2014-01-16 00:18:36"
+            "time": "2015-02-01 14:28:15"
         }
     ],
     "packages-dev": [],
@@ -44,6 +44,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
The 1.0.16 version of xrstf/composer-php52 throws these errors with the new Composer build, so I'm pushing this to 1.0.17. That seems to have resolved this issue.

```
Script xrstf\Composer52\Generator::onPostInstallCmd handling the post-autoload-dump event terminated with an exception
```
```
  [ErrorException]
  Declaration of xrstf\Composer52\AutoloadGenerator::getAutoloadRealFile() sh
  ould be compatible with Composer\Autoload\AutoloadGenerator::getAutoloadRea
  lFile($useClassMap, $useIncludePath, $targetDirLoader, $useIncludeFiles, $v
  endorPathCode, $appBaseDirCode, $suffix, $useGlobalIncludePath, $prependAut
  oloader, $classMapAuthoritative)
```