### PR TITLE
Give save image filter proper separated parameters

### DIFF
--- a/includes/naguro/modules/overlay/class-wc-naguro-overlay.php
+++ b/includes/naguro/modules/overlay/class-wc-naguro-overlay.php
@@ -61,10 +61,7 @@ class WC_Naguro_Overlay {
 		return $keys;
 	}
 
-	function save_image($args) {
-		$design_area = $args[0];
-		$image_ids = $args[1];
-
+	function save_image($design_area, $image_ids) {
 		if ( isset( $image_ids['overlay'][ $design_area['upload_key'] ] ) ) {
 			$image_id = $image_ids['overlay'][ $design_area['upload_key']];
 		} elseif ( isset( $design_area['product_overlay_id'] ) ) {

--- a/includes/woocommerce/admin/class-wc-naguro-product-meta-box.php
+++ b/includes/woocommerce/admin/class-wc-naguro-product-meta-box.php
@@ -366,7 +366,7 @@ class WC_Naguro_Product_Meta_Box {
 				$design_area['product_image_id'] = $image_id;
 			}
 
-			$design_area = apply_filters("naguro_woocommerce_filter_save_image", array($design_area, $image_ids));
+			$design_area = apply_filters( "naguro_woocommerce_filter_save_image", $design_area, $image_ids );
 
 			add_post_meta( $post_id, 'naguro_design_area', $design_area, false );
 		}


### PR DESCRIPTION
When the filter is not used, the old situation would return an array. This change removes the need for an array and has the filter use two separate parameters. The first will be auto returned, or to be returned from the implementing filters (as usually happens with WordPress filters :smile: ).

This solves #84 