### PR TITLE
Parameter count fix for image saving filter

### DIFF
--- a/includes/naguro/modules/overlay/class-wc-naguro-overlay.php
+++ b/includes/naguro/modules/overlay/class-wc-naguro-overlay.php
@@ -8,7 +8,7 @@ class WC_Naguro_Overlay {
 		add_filter("naguro_woocommerce_design_area_data", array($this, "handle_design_area_data"));
 		add_filter("naguro_woocommerce_save_keys", array($this, "add_overlays_to_keys"));
 		add_filter("naguro_woocommerce_file_keys", array($this, "add_overlay_to_keys"));
-		add_filter("naguro_woocommerce_filter_save_image", array($this, "save_image"));
+		add_filter("naguro_woocommerce_filter_save_image", array($this, "save_image"), 10, 2 );
 	}
 
 	function add_design_area_overlay_upload($rand, $design_area) {

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ You can find extensive documentation on [how to install plugins](http://codex.wo
 == Changelog ==
 
 = 1.1.3 - xx/xx/xxxx =
+* Fix: Prevent warning related to parameters on saving product with Naguro overlay enabled
 
 = 1.1.2 - 08/06/2015 =
 * Fix: Fixed default return value on the naguro_woocommerce_filter_save_image filter


### PR DESCRIPTION
The filter accepts two parameters since version 1.1.2 and therefore it should set the `accepted_args` parameter on the `add_filter` call to `2`.